### PR TITLE
fix: removed tensorflow requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'numpy',
         'pandas',
         'scipy',
-        'tensorflow-cpu',
+        # 'tensorflow-cpu',  # BigHat: Removed so we can handle tensorflow-cpu, tensorflow, and tensorflow-macos ourselves.
     ],
     tests_require=[
         'matplotlib',  # For notebook_utils_test.


### PR DESCRIPTION
Removed tensorflow requirement so pip doesn't try to automatically install tensorflow-cpu, which doesn't have any versions for macos.